### PR TITLE
Allow the usage of common css filters

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -24,6 +24,21 @@ const animations = [{
     [300, 0.25]
   ]
 }, {
+    prop: 'blur',
+    stops: [
+      [-100, 5],
+      [0, 1],
+      [100, 5]
+    ]
+  }, {
+    prop: 'invert',
+    stops: [
+      [-100, 0],
+      [0, 1],
+      [100, 0]
+    ]
+  }, {
+
   prop: 'opacity',
   stops: [
     [-300, 0],

--- a/src/animation-bus.js
+++ b/src/animation-bus.js
@@ -19,6 +19,22 @@ const transformUnits = {
 }
 const transformKeys = Object.keys(transformUnits)
 
+const filterUnits = {
+  blur: 'px',
+  brightness: '',
+  contrast: '%',
+  grayscale: '%',
+  'hue-rotate': 'deg',
+  invert: '%',
+  //opacity: '%',
+  saturate: '%',
+  sepia: '%'
+
+}
+
+const filterKeys = Object.keys(filterUnits)
+
+
 class AnimationBus {
   constructor({ animations, element, origin }) {
     this.animations = animations
@@ -29,16 +45,20 @@ class AnimationBus {
   getStyles(element = this.element) {
     const origin = this.origin(element)
     const transformValues = []
+    const filterValues = []
     const styles = {}
 
     this.animations.forEach(animation => {
       const prop = animation.prop
-      const unit = animation.unit || transformUnits[prop] || ''
+      const unit = animation.unit || transformUnits[prop] || filterUnits[prop] || ''
       const value = polylinearScale(animation.stops)(origin)
 
       if (transformKeys.indexOf(prop) > -1) {
         transformValues.push(`${prop}(${value}${unit})`)
-      } else {
+      } else if(filterKeys.indexOf(prop) > -1 ) {
+        filterValues.push(`${prop}(${value}${unit})`)
+      }
+       else {
         styles[prop] = `${value}${unit}`
       }
     })
@@ -47,6 +67,10 @@ class AnimationBus {
       styles.transform = transformValues.join(' ')
     }
 
+    if (filterValues.length) {
+      styles.filter = filterValues.join(' ')
+    }
+    console.log(filterValues)
     return styles
   }
 


### PR DESCRIPTION
This commit adds functionality similar to the preexisting transition styles, but for a subset of css filters.
The catalyst for this pull request is to allow other packages dependent on animation-bus, namely your other repo, [react-view-page](https://github.com/souporserious/react-view-pager), to work with css filters.

_Notes & Caveats:_
* Only those css filters which have a single value as input are currently respected. e.g. drop-shadow is not implemented.
* Opacity is commented out to maintain reasonable backwards compatibility.

Feel free to reject or modify as you see fit.

Thanks